### PR TITLE
Get it working on Ubuntu 23.10

### DIFF
--- a/de.unistuttgart.ims.reiter.treeanno.exec-war/pom.xml
+++ b/de.unistuttgart.ims.reiter.treeanno.exec-war/pom.xml
@@ -14,7 +14,7 @@
 			<plugin>
 				<groupId>org.apache.tomcat.maven</groupId>
 				<artifactId>tomcat7-maven-plugin</artifactId>
-				<version>2.3-SNAPSHOT</version>
+				<version>2.2</version>
 				<executions>
 					<execution>
 						<id>tomcat-run</id>

--- a/de.unistuttgart.ims.reiter.treeanno.tools/pom.xml
+++ b/de.unistuttgart.ims.reiter.treeanno.tools/pom.xml
@@ -70,7 +70,7 @@
     <dependency>
     	<groupId>de.unistuttgart.ims.reiter</groupId>
     	<artifactId>treeanno.api</artifactId>
-    	<version>0.2</version>
+    	<version>1.0.2</version>
     </dependency>
     <dependency>
     	<groupId>de.unistuttgart.ims.reiter</groupId>
@@ -78,10 +78,9 @@
     	<version>0.4-SNAPSHOT</version>
     </dependency>
     <dependency>
-		<groupId>org.apache.tomcat.maven</groupId>
+      <groupId>org.apache.tomcat.maven</groupId>
 			<artifactId>tomcat7-maven-plugin</artifactId>
-			<version>2.3-SNAPSHOT</version>
-			<scope>provided</scope>
-	</dependency>
+			<version>2.2</version>
+    </dependency>
   </dependencies>
 </project>

--- a/de.unistuttgart.ims.reiter.treeanno.util/pom.xml
+++ b/de.unistuttgart.ims.reiter.treeanno.util/pom.xml
@@ -71,7 +71,7 @@
     <dependency>
     	<groupId>de.unistuttgart.ims.reiter</groupId>
     	<artifactId>treeanno.api</artifactId>
-    	<version>0.2</version>
+    	<version>1.0.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/de.unistuttgart.ims.reiter.treeanno.war/pom.xml
+++ b/de.unistuttgart.ims.reiter.treeanno.war/pom.xml
@@ -219,7 +219,7 @@
 		<dependency>
 			<groupId>de.unistuttgart.ims.reiter</groupId>
 			<artifactId>treeanno.api</artifactId>
-			<version>0.6.13</version>
+			<version>1.0.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>

--- a/de.unistuttgart.ims.reiter.treeanno.war/src/main/profiles/sqlite/META-INF/context.xml
+++ b/de.unistuttgart.ims.reiter.treeanno.war/src/main/profiles/sqlite/META-INF/context.xml
@@ -3,5 +3,5 @@
     <Resource name="treeanno/jdbc"
     	type="javax.sql.DataSource"
     	driverClassName="org.sqlite.JDBC"
-    	url="jdbc:sqlite:treeanno.db" />
-</Context>	
+      url="jdbc:sqlite:/var/lib/tomcat9/webapps/treeanno.db" />
+</Context>


### PR DESCRIPTION
```
sudo apt install openjdk-8-jdk tomcat9
sudo update-java-alternatives --set /usr/lib/jvm/java-1.8.0-openjdk-amd64
```

Things that work:

```
mvn compile
mvn test
```

Then I also manage to deploy the in-memory DB server with:

```
mvn package -Pmem
sudo cp ./de.unistuttgart.ims.reiter.treeanno.war/target/TreeAnno-1.0.2.war /var/lib/tomcat9/webapps/
```

then visit:

```
http://localhost:8080/TreeAnno-1.0.2/
```

and it's running there.

And finally for the SQLite server:

```
mvn package -Psqlite
sudo chmod 777 /opt
sudo cp de.unistuttgart.ims.reiter.treeanno.war/target/TreeAnno-1.0.2.war /var/lib/tomcat9/webapps/
sudo service tomcat9 restart
```

The SQLite database is located at /var/lib/tomcat9/webapps/treeanno.db As per https://stackoverflow.com/questions/56827735/how-to-allow-tomcat-war-app-to-write-in-folder not many other locations are allowed by default.